### PR TITLE
Don't read uninitialized memory and display it in the test results

### DIFF
--- a/acceptance/gpu/intr_0_timing.s
+++ b/acceptance/gpu/intr_0_timing.s
@@ -93,10 +93,6 @@ test_finish:
   ld d,a
   ld a,(round4)
   ld e,a
-  ld a,(round5)
-  ld h,a
-  ld a,(round6) 
-  ld l,a
 
   setup_assertions
   assert_b $e0

--- a/acceptance/gpu/intr_1_timing.s
+++ b/acceptance/gpu/intr_1_timing.s
@@ -99,15 +99,15 @@ test_round7:
 test_finish:
   ld a,(round1)
   ld b,a
-  ld a,(round2)
-  ld c,a
-  ld a,(round3)
-  ld d,a
-  ld a,(round4)
-  ld e,a
+;  ld a,(round2)
+;  ld c,a
+;  ld a,(round3)
+;  ld d,a
+;  ld a,(round4)
+;  ld e,a
   ld a,(round5)
   ld h,a
-  ld a,(round6) 
+  ld a,(round6)
   ld l,a
   ld a,(round7)
 

--- a/acceptance/gpu/vblank_if_timing.s
+++ b/acceptance/gpu/vblank_if_timing.s
@@ -107,8 +107,8 @@ test_finish:
   ld e,a
   ld a,(round5)
   ld h,a
-  ld a,(round6) 
-  ld l,a
+;  ld a,(round6)
+;  ld l,a
 
   setup_assertions
   assert_b $e0


### PR DESCRIPTION
These reads appear to be left over from when Wilbert was iterating on his test design. They cause some displayed registers to have inconsistent values on hardware versus emulators, which prevents directly comparing the image output.